### PR TITLE
fix: add routing frontmatter, triggers, and context_files to template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,12 +9,14 @@ construct.yaml              # Manifest — skills, commands, metadata
 identity/
   persona.yaml              # Cognitive frame and voice
   expertise.yaml            # Domain knowledge and boundaries
+  NARRATIVE.md              # Identity narrative (prose, for L2 publishing)
 skills/                     # Skill implementations
   <skill-name>/
-    index.yaml              # Metadata + capability routing hints
+    index.yaml              # Metadata, triggers, capability routing hints
     SKILL.md                # Instructions and workflow
-commands/                   # Slash command prompt templates
+commands/                   # Slash command files with routing frontmatter
 schemas/                    # Validation schemas
+contexts/                   # Domain context files (optional)
 ```
 
 ## Adding a Skill
@@ -25,8 +27,19 @@ schemas/                    # Validation schemas
    ```yaml
    slug: my-skill
    name: "My Skill"
-   description: "What this skill does"
+
+   # Use "Use this skill IF..." for routing clarity
+   description: |
+     Use this skill IF user invokes `/my-command` OR needs [what it does].
+     Produces artifacts to [output path].
    version: 1.0.0
+
+   # Natural language triggers for proactive routing
+   # Without these, the skill only works via explicit /command
+   triggers:
+     - "/my-command"
+     - "natural language phrase"
+     - "another way users might ask"
 
    capabilities:
      model_tier: sonnet          # haiku | sonnet | opus
@@ -42,7 +55,7 @@ schemas/                    # Validation schemas
    ```
 
 3. Write instructions in `skills/my-skill/SKILL.md`:
-   - **Purpose** — when and why to use this skill
+   - **Trigger** — how to invoke this skill
    - **Workflow** — step-by-step execution instructions
    - **Boundaries** — what the skill does NOT do
 
@@ -53,15 +66,57 @@ schemas/                    # Validation schemas
        path: skills/my-skill
    ```
 
-5. Optionally create a command in `commands/my-command.md` that invokes it
-
 ## Adding a Command
 
-Commands are markdown prompt templates in `commands/`. Each command should:
+Commands are markdown files in `commands/` with **YAML frontmatter for routing**.
 
-- Establish the agent identity
-- Reference which skill to execute
-- Define constraints and output expectations
+The frontmatter is how the Loa runtime reliably dispatches commands to skills. Without it, the runtime must infer routing from prose — which is non-deterministic and causes inconsistent invocation.
+
+```yaml
+---
+name: "my-command"
+version: "1.0.0"
+description: |
+  What this command does.
+  Routes to my-skill for execution.
+
+arguments:
+  - name: "target"
+    description: "What to operate on"
+    required: false
+
+# REQUIRED: Machine-parseable skill binding
+agent: "my-skill"
+agent_path: "skills/my-skill"
+
+# Auto-load files into agent context on invocation
+# This is how the construct's identity activates
+context_files:
+  - path: "CLAUDE.md"
+    required: true
+  - path: "identity/NARRATIVE.md"
+    required: false
+---
+
+# My Command
+
+You are the **My Construct** agent. Execute the `my-skill` workflow.
+
+## Instructions
+...
+
+## Constraints
+...
+```
+
+### Key frontmatter fields
+
+| Field | Required | Purpose |
+|-------|----------|---------|
+| `agent` | Yes | Skill slug to route to |
+| `agent_path` | Yes | Path to skill directory |
+| `context_files` | Recommended | Files to load into agent context (identity, domain knowledge) |
+| `arguments` | Optional | Declared parameters |
 
 Register in `construct.yaml`:
 ```yaml
@@ -70,6 +125,20 @@ commands:
     path: commands/my-command.md
 ```
 
+## Adding Domain Context
+
+For constructs with domain-specific knowledge (brand guides, research bases, platform rules), use a `contexts/` or `grimoires/` directory:
+
+```
+contexts/
+  base/                     # Shared domain knowledge
+    domain-rules.md
+  overlays/                 # Project-specific overrides
+    project-config.yaml
+```
+
+Reference these in command frontmatter via `context_files` so they load on invocation.
+
 ## Updating Identity
 
 When expanding the construct's scope:
@@ -77,6 +146,7 @@ When expanding the construct's scope:
 - Add new domains to `identity/expertise.yaml` with honest depth ratings (1-5)
 - Update boundaries when the construct's refusal scope changes
 - Update persona only if the construct's cognitive approach fundamentally shifts
+- Add or update the identity narrative (`identity/*.md`) for publishing readiness
 
 ## Validation
 
@@ -92,6 +162,9 @@ yq eval '.' identity/expertise.yaml
 
 - **One skill, one responsibility** — keep skills focused and composable
 - **Capability metadata on every skill** — `model_tier`, `danger_level`, `effort_hint` enable intelligent routing
+- **Triggers on every skill** — without them, the skill is invisible to natural language routing
+- **Routing frontmatter on every command** — without `agent`/`agent_path`, invocation is non-deterministic
+- **context_files for identity** — without them, the agent executes skills without the construct's persona
 - **Document boundaries** — what a skill does NOT do is as important as what it does
 - **Be honest about depth** — a depth-3 domain that's accurate is better than a depth-5 that overpromises
 - **Write SKILL.md for experts** — specific inputs, outputs, edge cases, not vague descriptions

--- a/commands/example-command.md
+++ b/commands/example-command.md
@@ -1,8 +1,39 @@
-# Example Command
+---
+# CUSTOMIZE: Command routing metadata
+# These fields tell the Loa runtime how to dispatch this command.
+# Without them, the runtime must infer routing from prose — which is unreliable.
+name: "quick-review"
+version: "1.0.0"
+description: |
+  Run a fast code review focused on the most impactful issues.
+  Routes to quick-review skill for execution.
 
-> Replace this with your command's prompt template.
+# CUSTOMIZE: Command arguments (optional)
+arguments: []
 
-You are the **My Construct** agent. Execute the `example-skill` workflow.
+# REQUIRED: Machine-parseable binding to the skill directory
+# 'agent' = skill slug, 'agent_path' = path to skill directory
+agent: "quick-review"
+agent_path: "skills/example-simple"
+
+# CUSTOMIZE: Files to auto-load into agent context when this command fires
+# This is how the construct's identity and domain knowledge get activated.
+# Without context_files, the agent executes the skill mechanically
+# without embodying the construct's persona.
+context_files:
+  - path: "CLAUDE.md"
+    required: true
+  # CUSTOMIZE: Add your identity narrative for richer persona activation
+  # - path: "identity/ALEXANDER.md"
+  #   required: false
+  # CUSTOMIZE: Add domain context files
+  # - path: "contexts/base/domain-context.md"
+  #   required: false
+---
+
+# Quick Review
+
+You are the **Code Review Assistant**. Execute the `quick-review` workflow.
 
 ## Instructions
 

--- a/skills/example-full/index.yaml
+++ b/skills/example-full/index.yaml
@@ -1,7 +1,27 @@
 slug: write-docs
 name: Write Docs
-description: Generate documentation from code with structured analysis and quality gates
+
+# CUSTOMIZE: Use the "Use this skill IF..." pattern for routing clarity.
+# This tells the runtime WHEN to activate this skill, not just what it does.
+description: |
+  Use this skill IF user invokes `/write-docs` OR needs documentation
+  generated from code with traced examples and quality gates.
+
+  Produces documentation files to `docs/`:
+  - docs/api/<module>.md
+  - docs/components/<component>.md
+  - docs/guides/<topic>.md
 version: 1.0.0
+
+# CUSTOMIZE: Natural language patterns that trigger this skill.
+# These enable routing from conversational requests, not just /commands.
+# Without triggers, the skill can only be invoked via explicit slash command.
+triggers:
+  - "/write-docs"
+  - "generate documentation"
+  - "document this code"
+  - "write docs"
+  - "API documentation"
 
 capabilities:
   model_tier: sonnet

--- a/skills/example-simple/index.yaml
+++ b/skills/example-simple/index.yaml
@@ -1,7 +1,18 @@
 slug: quick-review
 name: Quick Review
-description: Fast code review focused on the most impactful issues
+
+# CUSTOMIZE: Use the "Use this skill IF..." pattern for routing clarity.
+description: |
+  Use this skill IF user invokes `/quick-review` OR needs a fast code review
+  focused on the most impactful issues by blast radius.
 version: 1.0.0
+
+# CUSTOMIZE: Natural language patterns that trigger this skill.
+triggers:
+  - "/quick-review"
+  - "review my code"
+  - "code review"
+  - "check for issues"
 
 capabilities:
   model_tier: sonnet


### PR DESCRIPTION
## Summary

The template was missing three runtime conventions that every construct in the network needs for reliable invocation. This is the root cause of inconsistent `/dig` behavior in K-Hole and similar issues across other constructs.

### What was missing

| Convention | Purpose | Without it |
|-----------|---------|------------|
| `agent`/`agent_path` in command frontmatter | Machine-parseable routing from `/command` to `skills/*/SKILL.md` | Runtime infers routing from prose — non-deterministic |
| `triggers` in skill index.yaml | Natural language routing ("review my code" → quick-review skill) | Skills invisible unless user knows exact `/command` |
| `context_files` in command frontmatter | Auto-load CLAUDE.md + identity into agent context | Agent executes skill without construct persona — mechanically correct but soul-flat |

### Evidence

Every working Loa-native command (`analyze-market.md`, `plan-launch.md`, `implement.md`) has all three. Every construct-base-derived command had none.

### Changes

- `commands/example-command.md` — full routing frontmatter with `agent`, `agent_path`, `context_files`, `arguments`
- `skills/example-full/index.yaml` — `triggers` array + `Use this skill IF...` description pattern
- `skills/example-simple/index.yaml` — same
- `CONTRIBUTING.md` — documents all three conventions with examples and rationale

## Test plan

- [ ] Verify `yq eval '.' construct.yaml` still passes
- [ ] Verify L0 validation passes (required fields, skill directories, CLAUDE.md)
- [ ] Review command frontmatter structure matches working Loa commands
- [ ] Review CONTRIBUTING.md for clarity on the three conventions

Generated with [Claude Code](https://claude.com/claude-code)