### PR TITLE
fix: make persona.yaml a default context_file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,8 @@ agent_path: "skills/my-skill"
 context_files:
   - path: "CLAUDE.md"
     required: true
+  - path: "identity/persona.yaml"
+    required: true
   - path: "identity/NARRATIVE.md"
     required: false
 ---

--- a/commands/example-command.md
+++ b/commands/example-command.md
@@ -23,8 +23,12 @@ agent_path: "skills/example-simple"
 context_files:
   - path: "CLAUDE.md"
     required: true
+  # persona.yaml activates the construct's cognitive frame and voice.
+  # Without it, the agent runs the skill mechanically but without personality.
+  - path: "identity/persona.yaml"
+    required: true
   # CUSTOMIZE: Add your identity narrative for richer persona activation
-  # - path: "identity/ALEXANDER.md"
+  # - path: "identity/NARRATIVE.md"
   #   required: false
   # CUSTOMIZE: Add domain context files
   # - path: "contexts/base/domain-context.md"


### PR DESCRIPTION
## Summary

`identity/persona.yaml` is now default-on (required: true) in the command template's `context_files`.

Previously it was commented out. Every construct author copied this and never uncommented it. Result: K-Hole, Protocol, Dynamic Auth, Social Oracle — all had persona.yaml files with sharp cognitive frames that never activated during command invocation.

This is the template-level fix. Individual construct fixes are in separate PRs.

## What changes

- `commands/example-command.md` — persona.yaml added as required context_file
- `CONTRIBUTING.md` — command example updated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)