### PR TITLE
feat: align template with discovery + composability (cycles 048/051)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,21 @@ You notice what's MISSING more than what's present — the error handler that do
 - Will NOT execute or test code — you read and reason, you don't run
 - Will NOT review generated code (migrations, lockfiles) — focus on human-authored code
 
+## What You Connect To
+
+<!-- CUSTOMIZE: Declare what your construct reads from and writes to.
+     This makes composition visible on the network graph.
+     The grimoire path IS the interface — constructs that share paths are connected. -->
+
+**Writes to**: `grimoires/code-review/findings/` — review findings and issue reports
+**Reads from**: None currently
+
+**Composes with**: Observer (user truth canvases ground review priorities)
+
+When other constructs produce artifacts you should consume, declare the grimoire path
+in `construct.yaml` under `composition_paths.reads`. The network surfaces these
+connections automatically — no event bus, no handshake. Just shared paths.
+
 ## Your Tools
 
 <!-- CUSTOMIZE: List your skills as capabilities, not commands.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ graph LR
 
 ---
 
+## Composition
+
+Constructs connect through grimoire paths — directories they write to and read from. Declare yours in `construct.yaml`:
+
+```yaml
+composition_paths:
+  writes:
+    - grimoires/my-construct/output/
+  reads:
+    - grimoires/laboratory/canvases/  # consume observer data
+```
+
+The network graph shows these connections automatically. No event bus needed — the filesystem IS the interface.
+
+See [Composability Guide](https://constructs.network/docs/composition) for patterns.
+
+---
+
 ## Two Example Skills
 
 **`example-simple`** — The starter. Trigger, workflow, boundaries. If your skill is one focused action, start here.

--- a/construct.yaml
+++ b/construct.yaml
@@ -25,6 +25,17 @@ author: your-name
 # SPDX license identifier
 license: MIT
 
+# Construct archetype — what kind of pack this is
+type: skill-pack
+
+# Network visibility — must be 'public' to appear on constructs.network
+visibility: public
+
+# Domain tags for discovery and categorization
+# See category list: marketing, development, security, analytics, documentation, operations, design, infrastructure
+domain:
+  - development
+
 # Skills provided by this construct
 # Each skill maps to a directory under skills/
 skills:
@@ -42,23 +53,37 @@ commands:
   - name: quick-review
     path: commands/example-command.md
 
+# Composition — how this construct connects to others
+# The grimoire path is the interface. Constructs that share paths are composed.
+compose_with:
+  - slug: observer
+    relationship: "Consumes user truth for review grounding"
+
+# Grimoire paths this construct reads from and writes to
+# These make implicit composition visible on the network graph
+composition_paths:
+  writes:
+    - grimoires/code-review/findings/
+  reads: []
+
 # Repository metadata
 repository:
   url: https://github.com/your-org/construct-code-review.git
   homepage: https://constructs.network/constructs/code-review-assistant
 
-# Event bus integration (optional — Level 2)
-# Uncomment when your construct emits or consumes events from other constructs
-# events:
-#   emits:
-#     - type: forge.code-review.issues_found
-#       description: Emitted when review finds issues
-#       data_schema:
-#         file_path: string
-#         severity: string
-#         count: number
-#   consumes:
-#     - event: forge.observer.feedback_captured
+# Event bus integration
+# emits: declare what your construct produces (encouraged from day one)
+# consumes: declare what you need from other constructs (add when real)
+events:
+  emits:
+    - type: forge.code-review.issues_found
+      description: Emitted when review finds issues
+  consumes: []
+
+# Governance (for cross-cutting constructs like vocabulary, taste, design rules)
+# Uncomment if your construct constrains how other constructs behave
+# governs: []
+# governed_by: []
 
 # Dependencies on other construct packs (optional — Level 2)
 # Uncomment when your construct depends on another

--- a/identity/expertise.yaml
+++ b/identity/expertise.yaml
@@ -5,6 +5,8 @@
 domains:
   - name: "Primary Domain"
     depth: 4                    # 1-5 scale (5 = world-class expert)
+                                # NOTE: depth >= 4 surfaces in API expertise_summary
+                                #       and boosts search ranking on constructs.network
     specializations:
       - "Core capability area"
       - "Secondary capability area"


### PR DESCRIPTION
## Summary

Aligns construct-base with the network's current state after cycles 048 (discovery) and 051 (composability).

### Added to construct.yaml
- `domain` — categorization for search and graph placement
- `visibility: public` — new constructs appear on network by default
- `type: skill-pack` — construct archetype
- `composition_paths` (writes/reads) — grimoire path declarations
- `compose_with` — affinity relationships
- `events.emits` uncommented — encouraged from day one
- `governs`/`governed_by` commented template

### Added to CLAUDE.md
- "What You Connect To" section — composition awareness

### Updated
- expertise.yaml depth note (depth >= 4 surfaces in API search)
- README.md composition section

### Not in this PR (follow-up)
- JSON Schema sync (15 → 40+ properties)

🤖 Generated with [Claude Code](https://claude.com/claude-code)