### PR TITLE
feat(template-v3): typed streams + persona handle example + butterfreezone note

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ graph LR
 
 ## Composition
 
-Constructs connect through grimoire paths — directories they write to and read from. Declare yours in `construct.yaml`:
+Constructs connect two ways.
+
+### 1. Grimoire paths — filesystem-layer composition
+
+Constructs connect through directories they write to and read from. Declare yours in `construct.yaml`:
 
 ```yaml
 composition_paths:
@@ -75,6 +79,23 @@ composition_paths:
 ```
 
 The network graph shows these connections automatically. No event bus needed — the filesystem IS the interface.
+
+Your `CLAUDE.md` MUST mirror these paths in a `## What You Connect To` section — operators read CLAUDE.md; the yaml is for the registry. Both must agree.
+
+### 2. Typed streams — in-memory-layer composition (doctrine v5 §17.4)
+
+For in-flight composition (runner pipe chains like `construct-compose.sh feel-audit`), declare the stream types your construct reads and writes:
+
+```yaml
+streams:
+  reads:
+    - Artifact        # file / path / content-addressable
+    - Operator-Model  # who the operator is (doctrine §14.2)
+  writes:
+    - Verdict         # evaluated judgment with severity + evidence
+```
+
+Five primitive types: **Signal** (raw observation) · **Verdict** (judgment) · **Artifact** (material) · **Intent** (operator routing signal) · **Operator-Model** (operator knowledge map). The composition runner verifies type compatibility at chain-build time — mismatches fail loud before any stage runs.
 
 See [Composability Guide](https://constructs.network/docs/composition) for patterns.
 
@@ -96,10 +117,13 @@ Both follow the same structure: what it is → how it works → the non-obvious 
 
 **`expertise.yaml`** — Bounded domains with depth ratings (1-5). Be honest. Boundaries are features — what your construct refuses to do builds trust.
 
+**`identity/<HANDLE>.md`** — Persona handles (UPPERCASE filenames, e.g. `ARCHITECT.md`). Operators invoke your construct via `@HANDLE`, `HANDLE`, or case-insensitive matches. See the starter `identity/ARCHITECT.md` for the shape.
+
 **`CLAUDE.md`** — Not documentation. Instructions injected into the AI runtime. Shapes how the agent *thinks*:
 - What it sees (the perceptual lens)
 - How it works (default behavior)
 - What it refuses (hard boundaries)
+- What it connects to (grimoire paths — MUST match `construct.yaml`)
 
 ---
 
@@ -136,6 +160,19 @@ pack_dependencies:
 ## Publish
 
 Push to GitHub. Register at [constructs.network](https://constructs.network). Others install with one command.
+
+### Auto-generated `CONSTRUCT-README.md`
+
+Post-install, Loa's butterfreezone adapter generates a per-pack `CONSTRUCT-README.md` from your `construct.yaml` + skills + identity/. It surfaces:
+
+- Persona handles (linked to `identity/<HANDLE>.md`)
+- Skill inventory with frontmatter descriptions
+- Command inventory
+- Declared streams (reads / writes)
+- Grimoire paths you compose through (SEED §12)
+- Install instructions
+
+You don't need to maintain that file — run `.claude/scripts/butterfreezone-construct-gen.sh <pack-path>` in a Loa-equipped repo to regenerate. Keep your hand-authored `README.md` for humans; `CONSTRUCT-README.md` is for agents.
 
 ---
 

--- a/construct.yaml
+++ b/construct.yaml
@@ -59,12 +59,26 @@ compose_with:
   - slug: observer
     relationship: "Consumes user truth for review grounding"
 
-# Grimoire paths this construct reads from and writes to
-# These make implicit composition visible on the network graph
+# Grimoire paths this construct reads from and writes to.
+# SEED §12: the grimoire path IS the interface. Two constructs writing
+# to the same path compose automatically; one writing + one reading
+# forms an implicit pipe edge. Declare every real read + write here.
 composition_paths:
   writes:
     - grimoires/code-review/findings/
   reads: []
+
+# Typed streams this construct consumes and produces (doctrine §3).
+# Five primitives: Signal · Verdict · Artifact · Intent · Operator-Model.
+# Consumed at composition-build-time by construct-compose.sh to verify
+# pipe compatibility before any stage runs. Empty arrays are legal but
+# will be flagged as pipe-ambiguous by construct-validate.sh.
+streams:
+  reads:
+    - Artifact        # the pull request / diff being reviewed
+    - Operator-Model  # who the operator is — tunes depth + register
+  writes:
+    - Verdict         # the review verdict (severity-tagged findings)
 
 # Repository metadata
 repository:
@@ -91,10 +105,24 @@ events:
 #   - slug: observer
 #     version: ">=1.0.0"
 
-# Identity files for persona and expertise
+# Identity files for persona and expertise.
+#
+# The construct-invocation glossary (Tier 4 persona-handle resolution) looks
+# up personas via `identity/<HANDLE>.md` filenames — UPPERCASE_HANDLE.md per
+# convention. Examples across the ecosystem:
+#
+#   artisan/identity/ALEXANDER.md
+#   k-hole/identity/STAMETS.md
+#   observer/identity/KEEPER.md
+#
+# If your construct ships a persona, author `identity/<HANDLE>.md` so the
+# operator can invoke via `@HANDLE` or mention the persona by name. The
+# starter identity/ARCHITECT.md file in this template shows the shape.
 identity:
   persona: identity/persona.yaml
   expertise: identity/expertise.yaml
+  handles:
+    - ARCHITECT
 
 # Post-install hook (optional)
 hooks:

--- a/identity/ARCHITECT.md
+++ b/identity/ARCHITECT.md
@@ -1,0 +1,60 @@
+# ARCHITECT — Code Review Assistant persona
+
+> *"Before I critique the edit, I reconstruct the intent. Every review is an argument with the diff's own argument."*
+
+<!--
+  This file is the persona handle. Operators invoke this construct via:
+
+    @ARCHITECT   — persona tier (doctrine §16.3, cycle-004 L2)
+    ARCHITECT    — case-insensitive persona match
+    /quick-review — command tier (pack-declared)
+    code-review-assistant — slug tier
+
+  The filename (UPPERCASE.md) is load-bearing: construct-index-gen.sh
+  extracts persona handles from the identity/ directory by walking files
+  matching ^[A-Z][A-Z0-9_]+\.md$.
+
+  Rename this file to your persona handle (e.g. REVIEWER.md, CURATOR.md).
+  You can ship multiple personas — one file per handle.
+-->
+
+## Who I am
+
+I am ARCHITECT — the code review persona for this construct. I read diffs
+the way a structural engineer reads blueprints: I care less about the line
+that changed than about what that line carries, what it breaks, and what
+it commits the codebase to going forward.
+
+My default mode is **blast-radius first**: when I look at a PR, I ask
+
+1. What user-facing behavior could this break?
+2. What downstream system could this cascade into?
+3. What invariant could this quietly violate?
+
+I surface the top 3–5. I don't list every style nit. Style belongs to
+other constructs; I belong to the question "could this hurt users."
+
+## How I think
+
+- **Evidence before verdict.** I cite file:line before I issue a severity.
+- **Severity over volume.** A single `critical` finding beats ten `info` nits.
+- **Boundaries are features.** I flag when a PR crosses a contract boundary
+  without also updating the consumer side.
+
+## What I refuse
+
+- Style commentary that has no user impact.
+- Inventing issues to meet a review quota.
+- Reviewing code I cannot ground in observable evidence (file:line, test
+  output, logs). Unground review is noise.
+
+## Related
+
+- SKILL: `quick-review` — one-pass review using this persona
+- Stream emissions: `Verdict` rows (severity + evidence chain) to
+  `grimoires/code-review/findings/`
+- Composes with: `observer` (user truth canvases calibrate review priority)
+
+<!-- Replace this file with your own persona. Keep the shape:
+     Who I am · How I think · What I refuse · Related.
+     Four sections is enough; more tends to drift toward documentation. -->


### PR DESCRIPTION
## Summary

Lands cycle-005 L3 template updates so fresh constructs derived from this template ship complete with the fields `construct-compose.sh` and `construct-validate.sh` (both in [loa-constructs](https://github.com/0xHoneyJar/loa-constructs) cycle-005) now gate against.

- `construct.yaml` gains explicit `streams: { reads, writes }` and `identity.handles` declarations
- New starter persona at `identity/ARCHITECT.md` showing the ecosystem's four-section persona shape
- `README.md` split composition into two layers (grimoire-path filesystem + typed-stream in-memory) and calls out the auto-generated `CONSTRUCT-README.md` pattern

## Why

Two convergent pressures from the cycle-005 SEED (runtime-integration):

1. **F28 closure** — the template already has `commands:` and `identity:`, but fresh constructs still lack stream declarations, which makes their pipe compatibility ambiguous once `construct-compose.sh` runs them.
2. **SEED §12 grimoires convention** — installed packs pre-dating template-v3 (e.g. artisan) have `construct.yaml` grimoire paths but their `CLAUDE.md` never mentions them. The template strengthens this mirror by explicitly referencing it in the README Identity section + pointing at the butterfreezone adapter as the generated-doc source of truth.

## Changes

| File | Change |
|---|---|
| `construct.yaml` | + `streams:` block (Artifact+Operator-Model in, Verdict out); + `identity.handles: [ARCHITECT]`; SEED §12 comment on `composition_paths` |
| `identity/ARCHITECT.md` | New starter persona handle file, four-section shape |
| `README.md` | Composition section split into two layers; Identity section mentions `identity/<HANDLE>.md` convention; Publish section describes auto-generated `CONSTRUCT-README.md` |

## Risk

- Placeholder audit: `your-name` / `your-org` / `CUSTOMIZE` markers remain (1 README, 6 CLAUDE.md, 7 construct.yaml). CI placeholder-block should still fire on unmodified ships.
- YAML validated (`yq eval '.' construct.yaml`). No schema version bump required — `streams:` is additive and `streams.reads/writes` arrays were already optional under schema_version 3.
- Backwards-compat: existing constructs derived from prior template versions continue to parse. `construct-validate.sh` downgrades missing `streams:` to a `low` advisory, not a block.

## Test plan

- [x] yq eval construct.yaml — valid
- [x] Placeholder markers preserved (7 / 6 / 1)
- [x] construct-validate.sh on existing packs remains non-blocking for missing streams
- [ ] After merge: gh repo create --template smoke test confirms fresh clone still builds

## References

- SEED: https://github.com/0xHoneyJar/loa-constructs/blob/main/grimoires/loa-constructs-seed-2026-04-21/cycle-005-SEED-runtime-integration.md Legs L3 + §12
- Doctrine v5 §3 typed streams · §17.4 grimoires-as-interface
- Sibling script: .claude/scripts/butterfreezone-construct-gen.sh (loa-constructs cycle-005 L6)

Closes AC-L3.1 through AC-L3.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)